### PR TITLE
Aliasy email

### DIFF
--- a/DataAccess/DAOs/Interfaces/IUserDao.cs
+++ b/DataAccess/DAOs/Interfaces/IUserDao.cs
@@ -6,7 +6,9 @@ namespace DataAccess.DAOs.Interfaces
 {
     public interface IUserDao
     {
-        Task<User> GetUserByEmailOrAliasAsync(string emailOrAlias);
+        Task<User> GetUserByAliasAsync(string alias);
+        Task<User> GetActiveUserByEmailAsync(string email);
+        Task<User> GetUserByIdentifierAsync(string identifier);
         Task<User> GetUserByIdAsync(int id);
         Task AddUserAsync(User user);
         Task UpdateLastLoginAsync(int userId);

--- a/Services/Implementations/UserService.cs
+++ b/Services/Implementations/UserService.cs
@@ -28,12 +28,15 @@ namespace Services.Implementations
 
         public async Task<User> Register(PlayerRegisterDto dto)
         {
-            if (await _userDao.GetUserByEmailOrAliasAsync(dto.Email) != null)
-                throw new ValidationException(ErrorMessages.DataUserAlreadyUse);
+            // Validar que el alias sea único (sin importar el estado)
+            var existingAlias = await _userDao.GetUserByAliasAsync(dto.Alias);
+            if (existingAlias != null)
+                throw new ValidationException("El alias ya está en uso.");
 
-            bool countryExists = await _countryDao.CountryExists(dto.CountryCode);
-            if (!countryExists)
-                throw new ValidationException(ErrorMessages.InvalidCountryCode);
+            // Validar email: se busca un usuario activo con ese email.
+            var existingEmailUser = await _userDao.GetActiveUserByEmailAsync(dto.Email);
+            if (existingEmailUser != null)
+                throw new ValidationException("El email ya está en uso por un usuario activo.");
 
             var hashedPassword = _passwordHasher.HashPassword(dto.Password);
 
@@ -52,25 +55,33 @@ namespace Services.Implementations
             };
 
             await _userDao.AddUserAsync(user);
-
             return user;
         }
 
         public async Task<User> CreateUserByAdmin(AdminRegisterDto dto, int adminId)
         {
+            // Validar que el admin que realiza la acción exista y tenga rol de Admin
             var admin = await _userDao.GetUserByIdAsync(adminId);
             if (admin == null || admin.Role != RoleEnum.Admin)
                 throw new ForbiddenException(ErrorMessages.AccesDenied);
 
-            if (dto.Role is RoleEnum.Admin or RoleEnum.Organizer or RoleEnum.Judge
-                && admin.Role != RoleEnum.Admin)
-            {
+            if (dto.Role is RoleEnum.Admin or RoleEnum.Organizer or RoleEnum.Judge && admin.Role != RoleEnum.Admin)
                 throw new ForbiddenException(ErrorMessages.AccesDenied);
-            }
 
             if (admin.Role == RoleEnum.Organizer && dto.Role != RoleEnum.Judge)
                 throw new ForbiddenException(ErrorMessages.AccesDenied);
 
+            // Validar que el alias sea único
+            var existingAlias = await _userDao.GetUserByAliasAsync(dto.Alias);
+            if (existingAlias != null)
+                throw new ValidationException("El alias ya está en uso.");
+
+            // Validar email: se busca un usuario activo con ese email.
+            var existingEmailUser = await _userDao.GetActiveUserByEmailAsync(dto.Email);
+            if (existingEmailUser != null)
+                throw new ValidationException("El email ya está en uso por un usuario activo.");
+
+            // Validar existencia del país
             bool countryExists = await _countryDao.CountryExists(dto.CountryCode);
             if (!countryExists)
                 throw new ValidationException(ErrorMessages.InvalidCountryCode);
@@ -85,6 +96,7 @@ namespace Services.Implementations
                 Email = dto.Email,
                 PasswordHash = hashedPassword,
                 CountryCode = dto.CountryCode,
+                AvatarUrl = dto.AvatarUrl,
                 Role = dto.Role,
                 CreatedBy = adminId,
                 CreatedAt = DateTime.UtcNow,
@@ -92,7 +104,6 @@ namespace Services.Implementations
             };
 
             await _userDao.AddUserAsync(user);
-
             return user;
         }
 

--- a/Services/Interfaces/IAuthService.cs
+++ b/Services/Interfaces/IAuthService.cs
@@ -7,7 +7,7 @@ namespace Services.Interfaces
 {
     public interface IAuthService
     {
-        Task<User> AuthenticateAsync(string emailOrAlias, string password);
+        Task<User> AuthenticateAsync(string identifier, string password);
         string GenerateJwtToken(User user);
     }
 }


### PR DESCRIPTION
Se agregaron los métodos:
- GetUserByAliasAsync: retorna el usuario según el alias (único sin importar estado).
- GetActiveUserByEmailAsync: retorna el usuario activo según el email.
- GetUserByIdentifierAsync: método auxiliar que primero busca por alias y, de no encontrarlo, busca por email (solo activos).

Se modificó la lógica de autenticación para:
- Buscar primero por alias y verificar que el usuario esté activo.
- Si no se encuentra por alias, buscar por email (únicamente usuarios activos).
- Devolver error "Usuario no activo" si se detecta que el usuario (por alias) está inactivo.

